### PR TITLE
Try to use the image based on alpine to reduce the startup latency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-stretch
+FROM golang:1.11.4-alpine
 
 LABEL "com.github.actions.name"="Detect Unmergeable"
 LABEL "com.github.actions.description"="Detect unmergeable pull requests"


### PR DESCRIPTION
This try to use the light-weight image to reduce the startup latency of this action.
This action takes 40~50sec for the startup.

```
docker image ls
REPOSITORY                    TAG                   IMAGE ID            CREATED             SIZE
golang                        1.11.4-stretch        dd46c1256829        4 weeks ago         775MB
golang                        1.11.4-alpine         f56365ec0638        2 months ago        310MB
```