### PR TITLE
Revert "Try to use the image based on alpine to reduce the startup latency"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-alpine
+FROM golang:1.11.4-stretch
 
 LABEL "com.github.actions.name"="Detect Unmergeable"
 LABEL "com.github.actions.description"="Detect unmergeable pull requests"


### PR DESCRIPTION
golang alpine image does not have `git`. It causes the build failure