### PR TITLE
Upgrade Go to 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     build_executor:
         working_directory: *workspace_root
         docker:
-            - image: golang:1.11.4-stretch
+            - image: golang:1.12-stretch
 
 
 ###########################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-stretch
+FROM golang:1.12-stretch
 
 LABEL "com.github.actions.name"="Detect Unmergeable"
 LABEL "com.github.actions.description"="Detect unmergeable pull requests"


### PR DESCRIPTION
* rel note: https://blog.golang.org/go1.12
* I'd like to try to specify only minor version to avoid to update the docker image on release every patch version.