### PR TITLE
Add custom skip label for compatibility with autorebase bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,22 @@ action "detect_unmergeable_pull_request_and_mark_them" {
   secrets = ["GITHUB_TOKEN"]
 }
 ```
+
+## Customization
+
+The default label of marking unmergeable is `S-needs-rebase`.
+This value is configurable if `LABEL_NEED_REBASE` environment variable is set.
+
+If it is not necessary to check mergeability, you can specify skip label to `LABEL_SKIP_CHECKING` environment variable.
+When `DO NOT MERGE` is given for example, a pull request has `DO NOT MERGE` will be ignored checking mergeability.
+
+```
+action "detect_unmergeable_pull_request_and_mark_them" {
+  uses = "cats-oss/github-action-detect-unmergeable@master"
+  secrets = ["GITHUB_TOKEN"]
+  env = {
+    LABEL_NEED_REBASE = "Rebase required"
+    LABEL_SKIP_CHECKING = "DO NOT MERGE"
+  }
+}
+```

--- a/main.go
+++ b/main.go
@@ -47,6 +47,11 @@ func main() {
 	}
 	log.Printf("We will supply `%v` if the pull request is unmergeable\n", needRebaseLabel)
 
+	labelSkipChecking := os.Getenv("LABEL_SKIP_CHECKING")
+	if labelSkipChecking != "" {
+		log.Printf("We will skip checking mergeability if the pull request has a label `%v`\n", labelSkipChecking)
+	}
+
 	eventData := loadJSONFile(githubEventPath)
 	if eventData == nil {
 		log.Fatal("Could not get eventData")
@@ -98,7 +103,7 @@ func main() {
 				return
 			}
 
-			checkAndMarkIfPullRequestUnmergeable(githubClient, repoOwner, repoName, pr, compareURL, needRebaseLabel)
+			checkAndMarkIfPullRequestUnmergeable(githubClient, repoOwner, repoName, pr, compareURL, needRebaseLabel, labelSkipChecking)
 		}(pr)
 	}
 	wg.Wait()

--- a/operation.go
+++ b/operation.go
@@ -79,7 +79,7 @@ func checkAndMarkIfPullRequestUnmergeable(client *github.Client, owner, repo str
 		return
 	}
 
-	if hasNeedRebaseLabel(oldPR.Labels, labelStatusNeedRebase) {
+	if hasLabel(oldPR.Labels, labelStatusNeedRebase) {
 		log.Printf("#%v has been labeled as %v\n", number, labelStatusNeedRebase)
 		return
 	}
@@ -143,10 +143,10 @@ func checkAndMarkIfPullRequestUnmergeable(client *github.Client, owner, repo str
 	wg.Wait()
 }
 
-func hasNeedRebaseLabel(labels []*github.Label, labelStatusNeedRebase string) bool {
+func hasLabel(labels []*github.Label, labelName string) bool {
 	for _, label := range labels {
 		name := label.GetName()
-		if name == labelStatusNeedRebase {
+		if name == labelName {
 			return true
 		}
 	}
@@ -169,7 +169,7 @@ func shouldMarkPullRequestNeedRebase(client *github.Client, owner, repo string, 
 	hasCompleted = true
 
 	// Check again to confirm the other instance of this action's behavior.
-	if hasNeedRebaseLabel(newPRInfoResponse.Labels, labelStatusNeedRebase) {
+	if hasLabel(newPRInfoResponse.Labels, labelStatusNeedRebase) {
 		shouldMark = false
 		return
 	}

--- a/operation.go
+++ b/operation.go
@@ -73,9 +73,14 @@ func isRelatedToPushedBranch(pullReqInfo *github.PullRequest, pushedBranchRef st
 	return
 }
 
-func checkAndMarkIfPullRequestUnmergeable(client *github.Client, owner, repo string, oldPR *github.PullRequest, compareURL, labelStatusNeedRebase string) {
+func checkAndMarkIfPullRequestUnmergeable(client *github.Client, owner, repo string, oldPR *github.PullRequest, compareURL, labelStatusNeedRebase, labelSkipChecking string) {
 	number := oldPR.GetNumber()
 	if number == 0 {
+		return
+	}
+
+	if labelSkipChecking != "" && hasLabel(oldPR.Labels, labelSkipChecking) {
+		log.Printf("#%v has skipping label: %v\n", number, labelSkipChecking)
 		return
 	}
 


### PR DESCRIPTION
Add skip option to environment variable. It is more compatible with an autorebase bot such as Dependabot to use skip label.