### PR TITLE
Add action.yml as new GitHub Action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: 'Detect Unmergeable'
+description: 'Detect unmergeable pull requests'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
As my feeling, I seem we can support new/old action format if we don't drop old metadata from Dockerfile