### PR TITLE
Parse push event data partially

### DIFF
--- a/json.go
+++ b/json.go
@@ -6,11 +6,31 @@ import (
 	"os"
 
 	"encoding/json"
-
-	"github.com/google/go-github/v25/github"
 )
 
-func loadJSONFile(path string) *github.PushEvent {
+// PushEventData is workaround to use *github.PushEvent.
+// If we available, we should use *github.PushEvent.
+// But we cannot use it by parsing error. See https://github.com/cats-oss/github-action-detect-unmergeable/issues/71
+type PushEventData struct {
+	Ref     *string `json:"ref,omitempty"`
+	Compare *string `json:"compare,omitempty"`
+}
+
+func (p *PushEventData) GetRef() string {
+	if p == nil || p.Ref == nil {
+		return ""
+	}
+	return *p.Ref
+}
+
+func (p *PushEventData) GetCompare() string {
+	if p == nil || p.Compare == nil {
+		return ""
+	}
+	return *p.Compare
+}
+
+func loadJSONFile(path string) *PushEventData {
 	jsonFile, err := os.Open(path)
 	defer jsonFile.Close()
 	if err != nil {
@@ -18,7 +38,7 @@ func loadJSONFile(path string) *github.PushEvent {
 		return nil
 	}
 
-	var data github.PushEvent
+	var data PushEventData
 
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 	if err := json.Unmarshal(byteValue, &data); err != nil {


### PR DESCRIPTION
The era of GitHub Action v1, we can parse _push_ event data json
with `*github.PushEvent` provided by go-github.

However, since GitHub Action v2, we cannot use the same way to parse it
because the json's _timestamp_ field format has been changed to
`"8/21/2019 6:06:04 AM"` and go-github does not expect its format.
(See go-github's issue 1254)

Fortunately, we don't require to parse all of its json.
We only need a part of it.

Thus we use self-defined type to unmarshal json.

For the future, if go-github implements the type to support events json
by GitHub Actions v2, it would be better to move to them.

Fix https://github.com/cats-oss/github-action-detect-unmergeable/issues/71