### PR TITLE
Rename the binary name in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ tags
 *.out
 
 # Generated
-app
+ghaction_unmergeable_detection
 
 # caches
 vendor/


### PR DESCRIPTION
This follow up https://github.com/cats-oss/github-action-detect-unmergeable/pull/90