### PR TITLE
Add CI settings for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  push:
+    branches:
+      # To supress this action launches twice on conditions which fulfills all of follwings:
+      #   - On pushing a new change to a branch.
+      #   - The branch is opening a pull request
+      #   - The branch is origin repository.
+      # We limits for push events for `master`.
+      # By [this link](https://github.community/t5/GitHub-Actions/How-to-trigger-a-single-build-on-either-push-or-pull-request/m-p/32469#M1144), 
+      # we seem that we need to add `branches` for `pull_request` event.
+      # However, actually, we don't have to limit a target branch for pull requests to suppress this problem.
+      # Even if we don't specify it, it triggers this action that pushing to the branch for pull request.
+      - master
+      # These branches are used by bors-ng.
+      - staging
+      - trying
+    tags-ignore:
+      # Ignore for release/
+      - v*.*.*
+  pull_request:
+
+jobs:
+  ci:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+            go-version: ^1.14 # The Go version to download (if necessary) and use.
+      - name: build
+        run: make build -j
+      - name: test
+        run: make test -j
+        env:
+          CI: true

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ clean: ## Clean up generated artifacts
 .PHONY: build
 build: clean ## Build the application
 	$(GO_BUILD) -o $(DIST_APP_BIN_NAME)
+
+.PHONY: test
+test: ## Run unit tests


### PR DESCRIPTION
We don't need a complex fork&join jobs.
So we don't have to use CircleCI.

Retry https://github.com/cats-oss/github-action-detect-unmergeable/pull/103