### PR TITLE
Add `permissions` instruction to the setup guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ on:
 jobs:
   detect_unmergeable_pull_request_and_mark_them:
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
+      pull-requests: write
     steps:
       - name: Run the action to detect unmergeable PRs
         # We recommend to use an arbitary latest version


### PR DESCRIPTION
This instruction is required for user that try to harden GH Actions.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
- https://docs.github.com/en/rest/overview/permissions-required-for-github-apps